### PR TITLE
[feat] 設定画面のスマホビュー対応

### DIFF
--- a/frontend/src/pages/pingpong_3D_config/index.ts
+++ b/frontend/src/pages/pingpong_3D_config/index.ts
@@ -55,7 +55,7 @@ class PingPongComponent implements Component {
     local: HTMLElement;
     remote: HTMLElement;
   };
-  private _commonSettings!: HTMLElement;
+  private _commonSettingsGroups!: NodeListOf<HTMLElement>;
   private _previewContainer!: HTMLElement;
 
   private _remoteUI!: {
@@ -97,9 +97,15 @@ class PingPongComponent implements Component {
   }
 
   private _renderModeCards(): string {
-    return MODES.map(
-      (mode, index) => `
-      <div class="pp3d-mode-card ${index === 0 ? "active" : ""}" data-mode="${mode.id}">
+    const repeatedModes = [...MODES, ...MODES, ...MODES];
+    
+    return repeatedModes.map((mode, index) => {
+      const isMain = index >= 3 && index <= 5;
+      const cloneClass = isMain ? "" : "md:hidden";
+      const activeClass = index === 3 ? "active" : "";
+
+      return `
+      <div class="pp3d-mode-card flex flex-col justify-center items-center ${activeClass} ${cloneClass} snap-center w-[85%] shrink-0 md:w-auto md:flex-1" data-mode="${mode.id}" data-index="${index}">
           <div class="pp3d-mode-icon">
               <img src="${mode.icon}" alt="${word(mode.titleKey)}" />
           </div>
@@ -108,127 +114,136 @@ class PingPongComponent implements Component {
               <p>${t(mode.descKey)}</p>
           </div>
       </div>
-    `,
-    ).join("");
+      `;
+    }).join("");
   }
   // TODO: ボールスピードを上げてパドルとの当たり判定が作用しないことを避けるためball_speedは提出時に削除予定
   render(): string {
     return `
       <div class="w-[900px] max-w-full" id="pp3d-config-root">
           <div class="pp3d-config">
-              <h2 class="pp3d-title">${t("pingpong3d_config")}</h2>
+              <h2 class="pp3d-title mb-4">${t("pingpong3d_config")}</h2>
 
-              <div class="pp3d-mode-selector">
+              <div class="pp3d-mode-selector relative flex overflow-x-auto snap-x snap-mandatory md:overflow-x-visible md:justify-center gap-4 mb-2 py-4 hide-scrollbar w-full px-[7.5%] md:px-0">
                   ${this._renderModeCards()}
               </div>
 
-              <div class="pp3d-settings-container">
+              <div class="pp3d-settings-container flex flex-col">
                   
-                  <div id="local-section" class="pp3d-section">
-                      <div class="pp3d-config-row">
-                          <label>${t("player2Type")}</label>
-                          <select id="player2-type">
-                              <option value="Player">${t("player2")}</option>
-                              <option value="Easy">${t("easyLv")}</option>
-                              <option value="Normal" selected>${t("normalLv")}</option>
-                              <option value="Hard">${t("hardLv")}</option>
-                              <option value="Remote" class="hidden">Remote</option>
-                          </select>
-                      </div>
-                  </div>
-                  <!-- Remote Config -->
-                  <div id="remote-section" class="pp3d-section hidden">
-                        <select id="remote-mode" class="hidden">
-                          <option value="guest">${t("guest")}</option>
-                          <option value="host">${t("host")}</option>
-                        </select>
-
-                        <div class="pp3d-config-row">
-                          <label class="pp3d-label">${t("room_id")}</label>
-                          <input id="remote-room-id" type="text" placeholder="${word("room_id_placeholder_guest")}" />
-                        </div>
-                  </div>
-
-                  <div class="pp3d-common-settings">
-                      <div class="pp3d-config-row">
-                          <label>${t("score_to_win")}</label>
-                          <input id="winning-score" type="number" min="1" max="20" value="3" />
-                      </div>
-
-                      <div class="pp3d-config-row">
-                          <label>${t("ball_speed")}</label>
-                          <input id="ball-speed" type="range" min="0.1" max="2" step="0.1" value="1" />
-                      </div>
-
-                      <div class="pp3d-config-row">
-                          <label>${t("count_speed")}</label>
-                          <select id="countdown-interval">
-                              <option value="500">${t("fast")}</option>
-                              <option value="1000" selected>${t("normal")}</option>
-                              <option value="2000">${t("slow")}</option>
-                          </select>
-                      </div>
+                  <div id="settings-scroll-container" class="flex overflow-x-auto snap-x snap-mandatory md:flex-col md:overflow-x-visible hide-scrollbar w-full gap-6 md:gap-0 pb-2 md:pb-0">
                       
-                      <div class="pp3d-config-row">
-                          <label>${t("stage")}</label>
-                          <select id="stage-select">
-                              <option value="0">${t("classic")}</option>
-                              <option value="1">${t("shadow")}</option>
-                              <option value="2">${t("warp")}</option>
-                          </select>
-                      </div>
+                      <div class="snap-center w-full shrink-0 md:w-full flex flex-col">
+                          
+                          <div id="local-section" class="pp3d-section">
+                              <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
+                                  <label class="w-full text-left md:w-[140px] shrink-0">${t("player2Type")}</label>
+                                  <select id="player2-type" class="w-full md:w-auto">
+                                      <option value="Player">${t("player2")}</option>
+                                      <option value="Easy">${t("easyLv")}</option>
+                                      <option value="Normal" selected>${t("normalLv")}</option>
+                                      <option value="Hard">${t("hardLv")}</option>
+                                      <option value="Remote" class="hidden">Remote</option>
+                                  </select>
+                              </div>
+                          </div>
+                          
+                          <div id="remote-section" class="pp3d-section hidden">
+                                <select id="remote-mode" class="hidden">
+                                  <option value="guest">${t("guest")}</option>
+                                  <option value="host">${t("host")}</option>
+                                </select>
 
-                      <div class="pp3d-config-row pp3d-inline-row">
-                          <label class="pp3d-label">${t("color1")}</label>
-                          <select id="paddle1-color" class="pp3d-color-select">
-                              <option value="blue">${t("blue")}</option>
-                              <option value="green">${t("green")}</option>
-                              <option value="red">${t("red")}</option>
-                              <option value="yellow">${t("yellow")}</option>
-                              <option value="white">${t("white")}</option>
-                              <option value="black">${t("black")}</option>
-                              <option value="pink">${t("pink")}</option>
-                          </select>
+                                <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
+                                  <label class="w-full text-left md:w-[140px] shrink-0">${t("room_id")}</label>
+                                  <input id="remote-room-id" type="text" placeholder="${word("room_id_placeholder_guest")}" class="w-full md:w-auto" />
+                                </div>
+                          </div>
 
-                          <div class="pp3d-length-group">
-                              <label class="pp3d-sub-label">${t("length")}</label>
-                              <input id="paddle1-length" type="range" min="1" max="10" step="1" value="8" />
+                          <div class="common-settings-group">
+                              <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
+                                  <label class="w-full text-left md:w-[140px] shrink-0">${t("score_to_win")}</label>
+                                  <input id="winning-score" type="number" min="1" max="20" value="3" class="w-full md:w-auto" />
+                              </div>
+
+                              <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
+                                  <label class="w-full text-left md:w-[140px] shrink-0">${t("ball_speed")}</label>
+                                  <input id="ball-speed" type="range" min="0.1" max="2" step="0.1" value="1" class="w-full md:w-auto" />
+                              </div>
+
+                              <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
+                                  <label class="w-full text-left md:w-[140px] shrink-0">${t("count_speed")}</label>
+                                  <select id="countdown-interval" class="w-full md:w-auto">
+                                      <option value="500">${t("fast")}</option>
+                                      <option value="1000" selected>${t("normal")}</option>
+                                      <option value="2000">${t("slow")}</option>
+                                  </select>
+                              </div>
+                              
+                              <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
+                                  <label class="w-full text-left md:w-[140px] shrink-0">${t("stage")}</label>
+                                  <select id="stage-select" class="w-full md:w-auto">
+                                      <option value="0">${t("classic")}</option>
+                                      <option value="1">${t("shadow")}</option>
+                                      <option value="2">${t("warp")}</option>
+                                  </select>
+                              </div>
+
+                              <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
+                                  <label class="w-full text-left md:w-[140px] shrink-0">${t("collapse_mode")}</label>
+                                  <div class="pp3d-toggle-container flex items-center gap-3 w-full md:w-auto">
+                                      <input id="rally-rush-toggle" type="checkbox" checked class="pp3d-toggle-input shrink-0" />
+                                      <span class="pp3d-toggle-text text-left">${t("collapse_explanation")}</span>
+                                  </div>
+                              </div>
                           </div>
                       </div>
 
-                      <div class="pp3d-config-row pp3d-inline-row">
-                          <label class="pp3d-label">${t("color2")}</label>
-                          <select id="paddle2-color" class="pp3d-color-select">
-                              <option value="green">${t("green")}</option>
-                              <option value="blue">${t("blue")}</option>
-                              <option value="red">${t("red")}</option>
-                              <option value="yellow">${t("yellow")}</option>
-                              <option value="white">${t("white")}</option>
-                              <option value="black">${t("black")}</option>
-                              <option value="pink">${t("pink")}</option>
-                          </select>
+                      <div class="snap-center w-full shrink-0 md:w-full flex flex-col common-settings-group">
+                          <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
+                              <label class="w-full text-left md:w-[140px] shrink-0">${t("color1")}</label>
+                              <select id="paddle1-color" class="pp3d-color-select w-full md:w-auto">
+                                  <option value="blue">${t("blue")}</option>
+                                  <option value="green">${t("green")}</option>
+                                  <option value="red">${t("red")}</option>
+                                  <option value="yellow">${t("yellow")}</option>
+                                  <option value="white">${t("white")}</option>
+                                  <option value="black">${t("black")}</option>
+                                  <option value="pink">${t("pink")}</option>
+                              </select>
 
-                          <div class="pp3d-length-group">
-                              <label class="pp3d-sub-label">${t("length")}</label>
-                              <input id="paddle2-length" type="range" min="1" max="10" step="1" value="8" />
+                              <div class="pp3d-length-group flex justify-between md:justify-start items-center w-full md:w-auto mt-2 md:mt-0 gap-4">
+                                  <label class="pp3d-sub-label md:ml-[20px] m-0 text-left shrink-0">${t("length")}</label>
+                                  <input id="paddle1-length" type="range" min="1" max="10" step="1" value="8" class="flex-1 md:w-auto" />
+                              </div>
+                          </div>
+
+                          <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
+                              <label class="w-full text-left md:w-[140px] shrink-0">${t("color2")}</label>
+                              <select id="paddle2-color" class="pp3d-color-select w-full md:w-auto">
+                                  <option value="green">${t("green")}</option>
+                                  <option value="blue">${t("blue")}</option>
+                                  <option value="red">${t("red")}</option>
+                                  <option value="yellow">${t("yellow")}</option>
+                                  <option value="white">${t("white")}</option>
+                                  <option value="black">${t("black")}</option>
+                                  <option value="pink">${t("pink")}</option>
+                              </select>
+
+                              <div class="pp3d-length-group flex justify-between md:justify-start items-center w-full md:w-auto mt-2 md:mt-0 gap-4">
+                                  <label class="pp3d-sub-label md:ml-[20px] m-0 text-left shrink-0">${t("length")}</label>
+                                  <input id="paddle2-length" type="range" min="1" max="10" step="1" value="8" class="flex-1 md:w-auto" />
+                              </div>
+                          </div>
+
+                          <div class="pp-preview-container w-full mt-2">
+                              <canvas id="previewCanvas3D"></canvas>
                           </div>
                       </div>
 
-                      <div class="pp3d-config-row">
-                          <label>${t("collapse_mode")}</label>
-                          <div class="pp3d-toggle-container">
-                              <input id="rally-rush-toggle" type="checkbox" checked class="pp3d-toggle-input" />
-                              <span class="pp3d-toggle-text">${t("collapse_explanation")}</span>
-                          </div>
-                      </div>
                   </div>
 
-                  <div class="pp-preview-container">
-                      <canvas id="previewCanvas3D"></canvas>
-                  </div>
-
-                  <div class="pp3d-config-row pp3d-config-row--button">
-                      <button id="pingpong-start-btn">${t("start")}</button>
+                  <div class="pp3d-config-row pp3d-config-row--button mt-6 flex justify-center w-full">
+                      <button id="pingpong-start-btn" class="w-full md:w-auto">${t("start")}</button>
                   </div>
               </div>
           </div>
@@ -254,7 +269,7 @@ class PingPongComponent implements Component {
       local: this._get("#local-section"),
       remote: this._get("#remote-section"),
     };
-    this._commonSettings = this._get(".pp3d-common-settings");
+    this._commonSettingsGroups = this._pp3dConfigRoot.querySelectorAll<HTMLElement>(".common-settings-group");
     this._previewContainer = this._get(".pp-preview-container");
 
     this._remoteUI = {
@@ -297,6 +312,7 @@ class PingPongComponent implements Component {
     document.documentElement.classList.add("overflow-hidden");
 
     this.init();
+    this.handleModeChange("local");
 
     this._previewUI.scene = new PreviewScene(this._previewUI.canvas);
 
@@ -314,12 +330,102 @@ class PingPongComponent implements Component {
     };
 
     // モードカードクリック時のイベント
+const modeSelector = this._get(".pp3d-mode-selector");
+    let isWarping = false;
+    let scrollTimeout: number;
+    const MOBILE_BREAKPOINT = 768;
+    const MODE_COUNT = MODES.length;
+    const MAIN_START_INDEX = MODE_COUNT;
+    const MAIN_END_INDEX = MAIN_START_INDEX + MODE_COUNT - 1;
+    const SCROLL_DEBOUNCE_MS = 15;
+    const WARP_COOLDOWN_MS = 5;
+
+    const initScrollPosition = () => {
+        if (window.innerWidth < MOBILE_BREAKPOINT) {
+            const initialCard = Array.from(this._modeCards).find(
+                c => parseInt(c.dataset.index || "0", 10) === MAIN_START_INDEX
+            ) as HTMLElement;
+            
+            if (initialCard) {
+                const scrollLeft = initialCard.offsetLeft - modeSelector.clientWidth / 2 + initialCard.clientWidth / 2;
+                modeSelector.scrollTo({ left: scrollLeft, behavior: "auto" });
+            }
+        }
+    };
+    setTimeout(initScrollPosition, 0);
+
+    modeSelector.addEventListener("scroll", () => {
+      if (window.innerWidth >= MOBILE_BREAKPOINT || isWarping) return;
+
+      const containerRect = modeSelector.getBoundingClientRect();
+      const containerCenter = containerRect.left + containerRect.width / 2;
+
+      let closestCard: HTMLElement | null = null;
+      let minDistance = Infinity;
+      let closestIndex = 0;
+
+      this._modeCards.forEach((card) => {
+        if (card.offsetParent === null) return; 
+
+        const cardRect = card.getBoundingClientRect();
+        const cardCenter = cardRect.left + cardRect.width / 2;
+        const distance = Math.abs(containerCenter - cardCenter);
+
+        if (distance < minDistance) {
+          minDistance = distance;
+          closestCard = card;
+          closestIndex = parseInt(card.dataset.index || "0", 10);
+        }
+      });
+
+      clearTimeout(scrollTimeout);
+      scrollTimeout = window.setTimeout(() => {
+        if (!closestCard) return;
+
+        if (!closestCard.classList.contains("active")) {
+          this._modeCards.forEach((c) => c.classList.remove("active"));
+          closestCard.classList.add("active");
+          this.handleModeChange(closestCard.dataset.mode);
+        }
+
+        let targetIndex = -1;
+        if (closestIndex < MAIN_START_INDEX) {
+          targetIndex = closestIndex + MODE_COUNT; 
+        } 
+        else if (closestIndex > MAIN_END_INDEX) {
+          targetIndex = closestIndex - MODE_COUNT; 
+        }
+
+        if (targetIndex !== -1) {
+          isWarping = true;
+          const targetCard = Array.from(this._modeCards).find(
+            c => parseInt(c.dataset.index || "0", 10) === targetIndex
+          ) as HTMLElement;
+
+          if (targetCard) {
+            const scrollLeft = targetCard.offsetLeft - modeSelector.clientWidth / 2 + targetCard.clientWidth / 2;
+            modeSelector.scrollTo({ left: scrollLeft, behavior: "auto" });
+            
+            this._modeCards.forEach((c) => c.classList.remove("active"));
+            targetCard.classList.add("active");
+          }
+          
+          setTimeout(() => { isWarping = false; }, WARP_COOLDOWN_MS);
+        }
+      }, SCROLL_DEBOUNCE_MS);
+    });
+
     this._modeCards.forEach((card) => {
       card.addEventListener("click", () => {
-        this._modeCards.forEach((c) => c.classList.remove("active"));
-        card.classList.add("active");
-        const mode = card.dataset.mode;
-        this.handleModeChange(mode);
+        if (window.innerWidth < MOBILE_BREAKPOINT) {
+          const scrollLeft = card.offsetLeft - modeSelector.clientWidth / 2 + card.clientWidth / 2;
+          modeSelector.scrollTo({ left: scrollLeft, behavior: "smooth" });
+        } else {
+          this._modeCards.forEach((c) => c.classList.remove("active"));
+          card.classList.add("active");
+          const mode = card.dataset.mode;
+          this.handleModeChange(mode);
+        }
       });
     });
 
@@ -401,7 +507,7 @@ class PingPongComponent implements Component {
     if (mode === "local") {
       this._sections.local.classList.remove("hidden");
       this._sections.remote.classList.add("hidden");
-      this._commonSettings.classList.remove("hidden");
+      this._commonSettingsGroups.forEach(g => g.classList.remove("hidden"));
       this._previewContainer.classList.remove("hidden");
 
       if (this._playerInputs.p2.type.value === "Remote") {
@@ -417,7 +523,7 @@ class PingPongComponent implements Component {
         this._remoteUI.roomInput.readOnly = true;
         this._sections.remote.classList.add("hidden");
         this._remoteUI.roomInput.value = "";
-        this._commonSettings.classList.remove("hidden");
+        this._commonSettingsGroups.forEach(g => g.classList.remove("hidden"));
         this._previewContainer.classList.remove("hidden");
       } else if (mode === "guest") {
         this._remoteUI.modeSelect.value = "guest";
@@ -426,7 +532,7 @@ class PingPongComponent implements Component {
           "room_id_placeholder_guest",
         );
         this._remoteUI.roomInput.focus();
-        this._commonSettings.classList.add("hidden");
+        this._commonSettingsGroups.forEach(g => g.classList.add("hidden"));
         this._previewContainer.classList.add("hidden");
       }
     }

--- a/frontend/src/pages/pingpong_3D_config/index.ts
+++ b/frontend/src/pages/pingpong_3D_config/index.ts
@@ -204,7 +204,7 @@ return repeatedModes.map((mode, index) => {
                       <div class="snap-center w-full shrink-0 md:w-full flex flex-col common-settings-group">
                           <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
                               <label class="w-full text-left md:w-[140px] shrink-0">${t("color1")}</label>
-                              <select id="paddle1-color" class="pp3d-color-select w-full md:w-auto">
+                              <select id="paddle1-color" class="w-full md:w-[90px]">
                                   <option value="blue">${t("blue")}</option>
                                   <option value="green">${t("green")}</option>
                                   <option value="red">${t("red")}</option>
@@ -222,7 +222,7 @@ return repeatedModes.map((mode, index) => {
 
                           <div class="pp3d-config-row flex flex-col md:flex-row md:items-center gap-2 md:gap-4">
                               <label class="w-full text-left md:w-[140px] shrink-0">${t("color2")}</label>
-                              <select id="paddle2-color" class="pp3d-color-select w-full md:w-auto">
+                              <select id="paddle2-color" class="w-full md:w-[90px]">
                                   <option value="green">${t("green")}</option>
                                   <option value="blue">${t("blue")}</option>
                                   <option value="red">${t("red")}</option>

--- a/frontend/src/pages/pingpong_3D_config/index.ts
+++ b/frontend/src/pages/pingpong_3D_config/index.ts
@@ -97,12 +97,15 @@ class PingPongComponent implements Component {
   }
 
   private _renderModeCards(): string {
+    const MODE_COUNT = MODES.length;
+    const MAIN_START_INDEX = MODE_COUNT;
+    const MAIN_END_INDEX = MAIN_START_INDEX + MODE_COUNT - 1;
     const repeatedModes = [...MODES, ...MODES, ...MODES];
     
-    return repeatedModes.map((mode, index) => {
-      const isMain = index >= 3 && index <= 5;
+return repeatedModes.map((mode, index) => {
+      const isMain = index >= MAIN_START_INDEX && index <= MAIN_END_INDEX;
       const cloneClass = isMain ? "" : "md:hidden";
-      const activeClass = index === 3 ? "active" : "";
+      const activeClass = index === MAIN_START_INDEX ? "active" : "";
 
       return `
       <div class="pp3d-mode-card flex flex-col justify-center items-center ${activeClass} ${cloneClass} snap-center w-[85%] shrink-0 md:w-auto md:flex-1" data-mode="${mode.id}" data-index="${index}">

--- a/frontend/src/pages/pingpong_3D_config/index.ts
+++ b/frontend/src/pages/pingpong_3D_config/index.ts
@@ -332,7 +332,7 @@ class PingPongComponent implements Component {
     // モードカードクリック時のイベント
 const modeSelector = this._get(".pp3d-mode-selector");
     let isWarping = false;
-    let scrollTimeout: number;
+    let scrollTimeout: number | undefined = undefined;
     const MOBILE_BREAKPOINT = 768;
     const MODE_COUNT = MODES.length;
     const MAIN_START_INDEX = MODE_COUNT;
@@ -378,7 +378,10 @@ const modeSelector = this._get(".pp3d-mode-selector");
         }
       });
 
-      clearTimeout(scrollTimeout);
+      if (scrollTimeout !== undefined)
+      {
+          clearTimeout(scrollTimeout);
+      }
       scrollTimeout = window.setTimeout(() => {
         if (!closestCard) return;
 

--- a/frontend/src/pages/pingpong_3D_config/style.css
+++ b/frontend/src/pages/pingpong_3D_config/style.css
@@ -238,10 +238,6 @@
   min-width: auto;
 }
 
-.pp3d-color-select {
-  width: 90px;
-}
-
 .pp3d-toggle-input {
   width: 18px;
   height: 18px;

--- a/frontend/src/pages/pingpong_3D_config/style.css
+++ b/frontend/src/pages/pingpong_3D_config/style.css
@@ -19,15 +19,7 @@
   line-height: 1;
 }
 
-.pp3d-mode-selector {
-  display: flex;
-  justify-content: center;
-  gap: 15px;
-  margin-bottom: 15px;
-}
-
 .pp3d-mode-card {
-  flex: 1;
   background: rgba(255, 255, 255, 0.1);
   border: 2px solid #333;
   border-radius: 10px;
@@ -36,10 +28,6 @@
   transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
   min-height: 90px;
   position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
   overflow: hidden;
 }
 
@@ -145,7 +133,6 @@
 }
 
 .pp3d-config label {
-  min-width: 140px;
   font-weight: 500;
   color: #ddd;
   font-size: 0.95rem;
@@ -168,7 +155,15 @@
     border-color 0.2s,
     box-shadow 0.2s;
   flex: 1;
-  max-width: 300px;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .pp3d-config input[type="text"],
+  .pp3d-config input[type="number"],
+  .pp3d-config select {
+    max-width: 300px;
+  }
 }
 
 .pp3d-config input:focus,
@@ -180,9 +175,15 @@
 .pp3d-config input[type="range"] {
   accent-color: #f77001;
   cursor: pointer;
-  max-width: 200px;
+  width: 100%;
   height: auto;
   padding: 0;
+}
+
+@media (min-width: 768px) {
+  .pp3d-config input[type="range"] {
+    max-width: 200px;
+  }
 }
 
 .pp3d-config button#pingpong-start-btn {
@@ -227,18 +228,11 @@
   background: black;
 }
 
-.pp3d-inline-row {
-  display: flex;
-  align-items: center;
-  gap: 15px;
-}
-
 .pp3d-label {
   min-width: 140px;
 }
 
 .pp3d-sub-label {
-  margin-left: 20px;
   font-size: 0.9em;
   color: #aaa;
   min-width: auto;
@@ -246,18 +240,6 @@
 
 .pp3d-color-select {
   width: 90px;
-}
-
-.pp3d-length-group {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.pp3d-toggle-container {
-  display: flex;
-  align-items: center;
-  gap: 12px;
 }
 
 .pp3d-toggle-input {
@@ -273,4 +255,12 @@
 
 .on-overflow {
   overflow: hidden;
+}
+
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+.hide-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }


### PR DESCRIPTION
＊mergeするbranch名は極力`feature/#{issue番号}`にしましょう.
## 🚀 概要 (Overview)
ゲーム設定画面のスマホビュー対応を行った
* **実装内容:** 
PCのみを想定した設定画面をスマホ対応させるために下記の対応を行った
- モード選択を左右操作で切り替える
- オプション選択も左右操作で二ページを切り替える

---

## 💡 変更点 (Changes)

* **ファイル/コンポーネント:**
    * `pages/pingpong3D_config/index.ts`: Tailwind CSSの適用と動作実装
    * `pages/pingpong3D_config/style.ts`: Tailwind CSSの適用とそれに伴う競合箇所の削除

---

## ✅ 確認事項 (Verification Checklist)

* **テスト環境:** (例: ローカル環境 / ステージング環境)
* **確認手順:**
    1.  サーバーを起動 (`make up` など)
    2.  ブラウザで `http://localhost:5173/register` にアクセス
    3.  スマホビュー対応がされているか確認
* **その他特記事項:** (例: 依存ライブラリのアップデートあり など)
UXの観点は問題ありそう。だけどいいいよね。
---
